### PR TITLE
Blocklist rewrite

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -765,7 +765,7 @@ class ModmailBot(commands.Bot):
     _block_msg_cooldown = dict()
 
 
-    # This has a bunch of side effectr
+    # This has a bunch of side effects
     async def is_blocked(
         self,
         author: discord.User,

--- a/bot.py
+++ b/bot.py
@@ -173,6 +173,9 @@ class ModmailBot(commands.Bot):
         logger.line()
         logger.info("discord.py: v%s", discord.__version__)
         logger.line()
+        if not self.config["blocked"] or not self.config["blocked_roles"]:
+            logger.warning("Un-migrated blocklists found. Please run the '[p]migrate blocklist' command after backing "
+                           "up your config/database. Blocklist functionality will be disabled until this is done.")
 
     async def load_extensions(self):
         for cog in self.loaded_cogs:
@@ -467,10 +470,14 @@ class ModmailBot(commands.Bot):
 
     @property
     def blocked_users(self) -> typing.Dict[str, str]:
+        """DEPRECATED, used blocklist instead"""
+        logger.warning("blocked_users is deprecated and does not function, its usage is a bug")
         return self.config["blocked"]
 
     @property
     def blocked_roles(self) -> typing.Dict[str, str]:
+        """DEPRECATED, used blocklist instead"""
+        logger.warning("blocked_roles is deprecated and does not function, its usage is a bug")
         return self.config["blocked_roles"]
 
     @property
@@ -724,6 +731,7 @@ class ModmailBot(commands.Bot):
         return True
 
     def check_manual_blocked_roles(self, author: discord.Member) -> bool:
+        logger.error("check_manual_blocked_roles is deprecated, usage is a bug.")
         for role in author.roles:
             if str(role.id) not in self.blocked_roles:
                 continue
@@ -740,6 +748,7 @@ class ModmailBot(commands.Bot):
         return True
 
     def check_manual_blocked(self, author: discord.User) -> bool:
+        logger.error("check_manual_blocked is deprecated, usage is a bug.")
         if str(author.id) not in self.blocked_users:
             return True
 
@@ -772,6 +781,24 @@ class ModmailBot(commands.Bot):
         channel: discord.TextChannel = None,
         send_message: bool = False,
     ) -> bool:
+        """
+        Check if a user is blocked for any reason and send a message if they are (if send_message is true).
+
+        If you are using this method with send_message set to false or not set,
+        You should be using blocklist.is_user_blocked() or blocklist.is_id_blocked()
+        if you only care whether a user is manually blocked then use blocklist.is_id_blocked().
+
+        Parameters
+        ----------
+        author
+        channel
+        send_message
+
+        Returns
+        -------
+        bool
+            Whether the user is blocked or not.
+        """
         member = self.guild.get_member(author.id) or await MemberConverter.convert(author)
         if member is None:
             # try to find in other guilds

--- a/bot.py
+++ b/bot.py
@@ -174,8 +174,10 @@ class ModmailBot(commands.Bot):
         logger.info("discord.py: v%s", discord.__version__)
         logger.line()
         if not self.config["blocked"] or not self.config["blocked_roles"]:
-            logger.warning("Un-migrated blocklists found. Please run the '[p]migrate blocklist' command after backing "
-                           "up your config/database. Blocklist functionality will be disabled until this is done.")
+            logger.warning(
+                "Un-migrated blocklists found. Please run the '[p]migrate blocklist' command after backing "
+                "up your config/database. Blocklist functionality will be disabled until this is done."
+            )
 
     async def load_extensions(self):
         for cog in self.loaded_cogs:

--- a/bot.py
+++ b/bot.py
@@ -731,6 +731,7 @@ class ModmailBot(commands.Bot):
         return True
 
     def check_manual_blocked_roles(self, author: discord.Member) -> bool:
+        """DEPRECATED"""
         logger.error("check_manual_blocked_roles is deprecated, usage is a bug.")
         for role in author.roles:
             if str(role.id) not in self.blocked_roles:
@@ -748,6 +749,7 @@ class ModmailBot(commands.Bot):
         return True
 
     def check_manual_blocked(self, author: discord.User) -> bool:
+        """DEPRECATED"""
         logger.error("check_manual_blocked is deprecated, usage is a bug.")
         if str(author.id) not in self.blocked_users:
             return True

--- a/bot.py
+++ b/bot.py
@@ -1229,7 +1229,7 @@ class ModmailBot(commands.Bot):
                     await user.typing()
 
     async def handle_reaction_events(self, payload):
-        user = self.get_user(payload.id)
+        user = self.get_user(payload.user_id)
         if user is None or user.bot:
             return
 
@@ -1315,8 +1315,8 @@ class ModmailBot(commands.Bot):
         if emoji_fmt != react_message_emoji:
             return
         channel = self.get_channel(payload.channel_id)
-        member = channel.guild.get_member(payload.id) or await channel.guild.fetch_member(
-            payload.id
+        member = channel.guild.get_member(payload.user_id) or await channel.guild.fetch_member(
+            payload.user_id
         )
         if member.bot:
             return

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1827,22 +1827,22 @@ class Modmail(commands.Cog):
         if reason:
             desc += f"\n- Reason: {reason}"
 
+        blocktype: BlockType
+
         if isinstance(user_or_role, discord.Role):
-            await self.bot.blocklist.block_user(user_id=user_or_role.id,
-                                                reason=reason,
-                                                expires_at=duration.dt if duration is not None else None,
-                                                blocked_by=ctx.author.id,
-                                                block_type=BlockType.ROLE)
+            blocktype = BlockType.ROLE
         elif isinstance(user_or_role, discord.User):
-            await self.bot.blocklist.block_user(user_id=user_or_role.id,
-                                                reason=reason,
-                                                expires_at=duration.dt if duration is not None else None,
-                                                blocked_by=ctx.author.id,
-                                                block_type=BlockType.USER)
+            blocktype = BlockType.USER
         else:
             return logger.warning(
                 f"{__name__}: cannot block user, user is neither an instance of Discord Role or User"
             )
+
+        await self.bot.blocklist.block_id(user_id=user_or_role.id,
+                                          reason=reason,
+                                          expires_at=duration.dt if duration is not None else None,
+                                          blocked_by=ctx.author.id,
+                                          block_type=blocktype)
 
         return await send_embed("Success", desc)
 

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1647,7 +1647,7 @@ class Modmail(commands.Cog):
 
         roles, users = [], []
 
-        blocked: list[blocklist.BlocklistItem] = await self.bot.blocklist.get_all_blocks()
+        blocked: list[blocklist.BlocklistEntry] = await self.bot.blocklist.get_all_blocks()
 
         for item in blocked:
             human_blocked_at = discord.utils.format_dt(item.timestamp, style="R")
@@ -1754,16 +1754,16 @@ class Modmail(commands.Cog):
         await self.bot.config.update()
 
         blocked: bool
-        foo: blocklist.BlocklistItem
+        blocklist_entry: blocklist.BlocklistEntry
 
-        blocked, foo = await self.bot.blocklist.is_id_blocked(user.id)
+        blocked, blocklist_entry = await self.bot.blocklist.is_id_blocked(user.id)
         if blocked:
             await self.bot.blocklist.unblock_id(user.id)
             embed = discord.Embed(
                 title="Success",
                 description=f"""
                 {mention} has been whitelisted.
-                They were previously blocked by <@{foo.blocking_user_id}> {" for "+foo.reason if foo.reason is not None else ""}.
+                They were previously blocked by <@{blocklist_entry.blocking_user_id}> {" for "+blocklist_entry.reason if blocklist_entry.reason is not None else ""}.
                 """,
                 color=self.bot.main_color,
             )

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1562,7 +1562,7 @@ class Modmail(commands.Cog):
             elif u.bot:
                 errors.append(f"{u} is a bot, cannot add to thread.")
                 users.remove(u)
-            elif await self.bot.is_blocked(u):
+            elif await self.bot.blocklist.is_user_blocked(u):
                 ref = f"{u.mention} is" if ctx.author != u else "You are"
                 errors.append(f"{ref} currently blocked from contacting {self.bot.user.name}.")
                 users.remove(u)

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -1836,11 +1836,13 @@ class Modmail(commands.Cog):
                 f"{__name__}: cannot block user, user is neither an instance of Discord Role or User"
             )
 
-        await self.bot.blocklist.block_id(user_id=user_or_role.id,
-                                          reason=reason,
-                                          expires_at=duration.dt if duration is not None else None,
-                                          blocked_by=ctx.author.id,
-                                          block_type=blocktype)
+        await self.bot.blocklist.block_id(
+            user_id=user_or_role.id,
+            reason=reason,
+            expires_at=duration.dt if duration is not None else None,
+            blocked_by=ctx.author.id,
+            block_type=blocktype,
+        )
 
         return await send_embed("Success", desc)
 

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1960,7 +1960,9 @@ class Utility(commands.Cog):
             try:
                 await migrations.migrate_blocklist(self.bot)
             except Exception as e:
-                await ctx.send(embed=discord.Embed(title="Error", description=str(e), color=self.bot.error_color))
+                await ctx.send(
+                    embed=discord.Embed(title="Error", description=str(e), color=self.bot.error_color)
+                )
                 raise e
 
         await ctx.send(embed=discord.Embed(title="Success", color=self.bot.main_color))

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -22,7 +22,7 @@ from discord.ext import commands, tasks
 from discord.ext.commands.view import StringView
 from pkg_resources import parse_version
 
-from core import checks, utils
+from core import checks, migrations, utils
 from core.changelog import Changelog
 from core.models import HostingMethod, InvalidConfigError, PermissionLevel, UnseenFormatter, getLogger
 from core.paginator import EmbedPaginatorSession, MessagePaginatorSession
@@ -1951,6 +1951,19 @@ class Utility(commands.Cog):
             )
 
         await EmbedPaginatorSession(ctx, *embeds).run()
+
+    @commands.command()
+    @checks.has_permissions(PermissionLevel.OWNER)
+    async def migrate(self, ctx, migration: str):
+        """Perform a given database migration"""
+        if migration == "blocklist":
+            try:
+                await migrations.migrate_blocklist(self.bot)
+            except Exception as e:
+                await ctx.send(embed=discord.Embed(title="Error", description=str(e), color=self.bot.error_color))
+                raise e
+
+        await ctx.send(embed=discord.Embed(title="Success", color=self.bot.main_color))
 
     @commands.command()
     @checks.has_permissions(PermissionLevel.OWNER)

--- a/core/blocklist.py
+++ b/core/blocklist.py
@@ -81,7 +81,7 @@ class Blocklist:
             return False
         return True
 
-    async def is_id_blocked(self, user_or_role_id: int) -> bool:
+    async def is_id_blocked(self, user_or_role_id: int) -> Tuple[bool, Optional[BlocklistItem]]:
         """
         Checks if the given ID is blocked
 
@@ -100,8 +100,8 @@ class Blocklist:
         """
         result = await self.blocklist_collection.find_one({"id": user_or_role_id})
         if result is None:
-            return False
-        return True
+            return False, None
+        return True, BlocklistItem.from_dict(result)
 
     async def get_all_blocks(self) -> list[BlocklistItem]:
         """
@@ -137,7 +137,7 @@ class Blocklist:
         #
 
         if str(member.id) in self.bot.blocked_whitelisted_users:
-            return False
+            return False, None
 
         blocked = await self.blocklist_collection.find_one({"id": member.id})
         if blocked is not None:

--- a/core/blocklist.py
+++ b/core/blocklist.py
@@ -41,7 +41,7 @@ class BlocklistEntry:
             reason=data["reason"],
             timestamp=data["timestamp"],
             blocking_user_id=data["blocking_user_id"],
-            type=data["type"]
+            type=data["type"],
         )
 
 
@@ -50,7 +50,8 @@ class Blocklist:
 
     def __init__(self: Self, bot) -> None:
         self.blocklist_collection = bot.api.db.blocklist.with_options(
-            codec_options=CodecOptions(tz_aware=True, tzinfo=datetime.timezone.utc))
+            codec_options=CodecOptions(tz_aware=True, tzinfo=datetime.timezone.utc)
+        )
         self.bot = bot
 
     async def setup(self):
@@ -60,18 +61,26 @@ class Blocklist:
     async def add_block(self, block: BlocklistEntry) -> None:
         await self.blocklist_collection.insert_one(block.__dict__)
 
-    async def block_id(self, user_id: int, expires_at: Optional[datetime.datetime], reason: str,
-                       blocked_by: int, block_type: BlockType) -> None:
+    async def block_id(
+        self,
+        user_id: int,
+        expires_at: Optional[datetime.datetime],
+        reason: str,
+        blocked_by: int,
+        block_type: BlockType,
+    ) -> None:
         now = datetime.datetime.utcnow()
 
-        await self.add_block(block=BlocklistEntry(
-            id=user_id,
-            expires_at=expires_at,
-            reason=reason,
-            timestamp=now,
-            blocking_user_id=blocked_by,
-            type=block_type
-        ))
+        await self.add_block(
+            block=BlocklistEntry(
+                id=user_id,
+                expires_at=expires_at,
+                reason=reason,
+                timestamp=now,
+                blocking_user_id=blocked_by,
+                type=block_type,
+            )
+        )
 
     async def unblock_id(self, user_or_role_id: int) -> bool:
         result = await self.blocklist_collection.delete_one({"id": user_or_role_id})

--- a/core/blocklist.py
+++ b/core/blocklist.py
@@ -1,0 +1,134 @@
+import datetime
+import enum
+from dataclasses import dataclass
+from typing import Optional, Self, Tuple
+
+import discord
+import isodate
+from bson import CodecOptions, ObjectId
+from motor.core import AgnosticCollection
+
+
+class BlockType(enum.IntEnum):
+    USER = 0
+    ROLE = 1
+
+
+class BlockReason(enum.StrEnum):
+    GUILD_AGE = "guild_age"
+    ACCOUNT_AGE = "account_age"
+    BLOCKED_ROLE = "blocked_role"
+    BLOCKED_USER = "blocked_user"
+
+
+@dataclass(frozen=True)
+class BlockedUser:
+    # _id: ObjectId
+    # May be role or user id
+    id: int
+    expires_at: Optional[datetime.datetime]
+    reason: str
+    timestamp: datetime.datetime
+    blocking_user_id: int
+    # specifies if the id is a role or user id
+    type: BlockType
+
+
+class Blocklist:
+    blocklist_collection: AgnosticCollection
+
+    def __init__(self: Self, bot) -> None:
+        self.blocklist_collection = bot.api.db.blocklist.with_options(
+            codec_options=CodecOptions(tz_aware=True, tzinfo=datetime.timezone.utc))
+        self.bot = bot
+
+    async def setup(self):
+        index_info = await self.blocklist_collection.index_information()
+        print(index_info)
+        await self.blocklist_collection.create_index("id")
+        await self.blocklist_collection.create_index("expires_at", expireAfterSeconds=0)
+
+    async def block_user(self, user_id: int, expires_at: Optional[datetime.datetime], reason: str,
+                         blocked_by: int) -> None:
+        now = datetime.datetime.utcnow()
+
+        await self.blocklist_collection.insert_one(BlockedUser(
+            id=user_id,
+            expires_at=expires_at,
+            reason=reason,
+            timestamp=now,
+            blocking_user_id=blocked_by,
+            type=BlockType.USER
+        ))
+
+    # we will probably want to cache these
+    async def is_user_blocked(self, member: discord.Member) -> Tuple[bool, Optional[BlockReason]]:
+        """
+        Side effect free version of is_blocked
+
+        Parameters
+        ----------
+        member
+
+        Returns
+        -------
+        True if the user is blocked
+        """
+        #
+
+        if str(member.id) in self.bot.blocked_whitelisted_users:
+            return False
+
+        blocked = await self.blocklist_collection.find_one({"id": member.id})
+        if blocked is not None:
+            print(blocked)
+            return True, BlockReason.BLOCKED_USER
+
+        roles = member.roles
+
+        blocked = await self.blocklist_collection.find_one(filter={"id": {"$in": [r.id for r in roles]}})
+        if blocked is not None:
+            return True, BlockReason.BLOCKED_ROLE
+
+        if not self.is_valid_account_age(member):
+            print("account_age")
+            return True, BlockReason.ACCOUNT_AGE
+        if not self.is_valid_guild_age(member):
+            print("guild_age")
+            return True, BlockReason.GUILD_AGE
+
+        return False, None
+
+    def is_valid_account_age(self, author: discord.User) -> bool:
+        account_age = self.bot.config.get("account_age")
+
+        if account_age is None or account_age == isodate.Duration():
+            return True
+
+        now = discord.utils.utcnow()
+
+        min_account_age = author.created_at + account_age
+
+        if min_account_age < now:
+            # User account has not reached the required time
+            return False
+        return True
+
+    def is_valid_guild_age(self, author: discord.Member) -> bool:
+        guild_age = self.bot.config.get("guild_age")
+
+        if guild_age is None or guild_age == isodate.Duration():
+            return True
+
+        now = discord.utils.utcnow()
+
+        if not hasattr(author, "joined_at"):
+            self.bot.logger.warning("Not in guild, cannot verify guild_age, %s.", author.name)
+            return False
+
+        min_guild_age = author.joined_at + guild_age
+
+        if min_guild_age > now:
+            # User has not stayed in the guild for long enough
+            return False
+        return True

--- a/core/blocklist.py
+++ b/core/blocklist.py
@@ -139,7 +139,6 @@ class Blocklist:
 
         blocked = await self.blocklist_collection.find_one({"id": member.id})
         if blocked is not None:
-            print(blocked)
             return True, BlockReason.BLOCKED_USER
 
         roles = member.roles
@@ -149,10 +148,8 @@ class Blocklist:
             return True, BlockReason.BLOCKED_ROLE
 
         if not self.is_valid_account_age(member):
-            print("account_age")
             return True, BlockReason.ACCOUNT_AGE
         if not self.is_valid_guild_age(member):
-            print("guild_age")
             return True, BlockReason.GUILD_AGE
 
         return False, None

--- a/core/migrations.py
+++ b/core/migrations.py
@@ -1,0 +1,121 @@
+import datetime
+import re
+
+from core import blocklist
+from core.models import getLogger
+
+logger = getLogger(__name__)
+
+old_format_matcher = re.compile("by ([\w]*#[\d]{1,4})(?: until <t:(\d*):f>)?.")
+
+
+def _convert_legacy_v2_block_format(k, v: dict, block_type: blocklist.BlockType) -> blocklist.BlockedUser:
+    blocked_by = int(v["blocked_by"])
+    if "until" in v:
+        # todo make sure this is the correct from format
+        blocked_until = datetime.datetime.fromisoformat(v["until"])
+    else:
+        blocked_until = None
+    if "reason" in v:
+        reason = v["reason"]
+    else:
+        reason = None
+    blocked_ts = datetime.datetime.fromisoformat(v["blocked_at"])
+    return blocklist.BlockedUser(
+        id=int(k),
+        expires_at=blocked_until,
+        reason=reason,
+        timestamp=blocked_ts,
+        blocking_user_id=blocked_by,
+        type=block_type
+    )
+
+
+def _convert_legacy_block_format(k, v: str, block_type: blocklist.BlockType) -> blocklist.BlockedUser:
+    match = old_format_matcher.match(v)
+    # blocked_by = match.group(1)
+    blocked_until = match.group(2)
+    if blocked_until is not None:
+        blocked_until = datetime.datetime.fromtimestamp(int(blocked_until), tz=datetime.timezone.utc)
+
+    return blocklist.BlockedUser(
+        id=int(k),
+        expires_at=blocked_until,
+        reason=f"migrated from old format `{v}`",
+        timestamp=datetime.datetime.utcnow(),
+        # I'm not bothering to fetch the user object here, discords username migrations will have broken all of them
+        blocking_user_id=0,
+        type=block_type
+    )
+
+
+async def _convert_legacy_block_list(foo: dict, blocklist_batch: list[blocklist.BlockedUser],
+                                     block_type: blocklist.BlockType, bot) -> int:
+    skipped = 0
+
+    for k, v in foo.items():
+        # handle new block format
+        if type(v) is dict:
+            block = _convert_legacy_v2_block_format(k, v, block_type=block_type)
+            if block.expires_at is not None and block.expires_at < datetime.datetime.now(datetime.timezone.utc):
+                logger.debug("skipping expired block entry")
+                skipped += 1
+                continue
+            logger.debug(f"migrating new format {v}")
+            blocklist_batch.append(block)
+
+            continue
+
+        match = old_format_matcher.match(v)
+        blocked_by = match.group(1)
+        blocked_until = match.group(2)
+        if blocked_until is not None:
+            blocked_until = datetime.datetime.fromtimestamp(int(blocked_until), tz=datetime.timezone.utc)
+
+        # skip this item if blocked_until occurred in the past
+        if blocked_until is not None and blocked_until < datetime.datetime.now(datetime.timezone.utc):
+            logger.debug("skipping expired block entry")
+            skipped += 1
+            continue
+
+        logger.debug(f"migrating id:{k} ts:{blocked_until} blocker:{blocked_by}")
+
+        blocklist_batch.append(blocklist.BlockedUser(
+            id=int(k),
+            expires_at=blocked_until,
+            reason=f"migrated from old format `{v}`",
+            timestamp=datetime.datetime.utcnow(),
+            # I'm not bothering to fetch the user object here, discords username migrations will have broken all of them
+            blocking_user_id=0,
+            type=blocklist.BlockType.USER
+        ))
+        if len(blocklist_batch) >= 100:
+            await bot.api.db.blocklist.insert_many([x.__dict__ for x in blocklist_batch])
+            blocklist_batch.clear()
+
+    return skipped
+
+
+async def migrate_blocklist(bot):
+    start_time = datetime.datetime.utcnow()
+
+    blocked_users = bot.blocked_users
+    logger.info(f"preparing to migrate blocklist")
+    skipped = 0
+
+    blocklist_batch: list[blocklist.BlockedUser] = []
+    logger.info(f"preparing to process {len(blocked_users)} blocked users")
+    skipped += await _convert_legacy_block_list(foo=blocked_users, blocklist_batch=blocklist_batch,
+                                                block_type=blocklist.BlockType.USER, bot=bot)
+    logger.info(f"processed blocked users")
+    logger.info(f"preparing to process {len(bot.blocked_roles)} blocked roles")
+    skipped += await _convert_legacy_block_list(foo=bot.blocked_roles, blocklist_batch=blocklist_batch,
+                                                block_type=blocklist.BlockType.ROLE, bot=bot)
+    logger.info(f"processed blocked roles")
+
+    await bot.api.db.blocklist.insert_many([x.__dict__ for x in blocklist_batch])
+    blocklist_batch.clear()
+
+    logger.info(f"Migration complete! skipped {skipped} entries")
+    logger.info(f"migrated in {datetime.datetime.utcnow() - start_time}")
+    return

--- a/core/migrations.py
+++ b/core/migrations.py
@@ -9,7 +9,7 @@ logger = getLogger(__name__)
 old_format_matcher = re.compile("by ([\w]*#[\d]{1,4})(?: until <t:(\d*):f>)?.")
 
 
-def _convert_legacy_v2_block_format(k, v: dict, block_type: blocklist.BlockType) -> blocklist.BlocklistItem:
+def _convert_legacy_v2_block_format(k, v: dict, block_type: blocklist.BlockType) -> blocklist.BlocklistEntry:
     blocked_by = int(v["blocked_by"])
     if "until" in v:
         # todo make sure this is the correct from format
@@ -21,7 +21,7 @@ def _convert_legacy_v2_block_format(k, v: dict, block_type: blocklist.BlockType)
     else:
         reason = None
     blocked_ts = datetime.datetime.fromisoformat(v["blocked_at"])
-    return blocklist.BlocklistItem(
+    return blocklist.BlocklistEntry(
         id=int(k),
         expires_at=blocked_until,
         reason=reason,
@@ -31,14 +31,14 @@ def _convert_legacy_v2_block_format(k, v: dict, block_type: blocklist.BlockType)
     )
 
 
-def _convert_legacy_block_format(k, v: str, block_type: blocklist.BlockType) -> blocklist.BlocklistItem:
+def _convert_legacy_block_format(k, v: str, block_type: blocklist.BlockType) -> blocklist.BlocklistEntry:
     match = old_format_matcher.match(v)
     # blocked_by = match.group(1)
     blocked_until = match.group(2)
     if blocked_until is not None:
         blocked_until = datetime.datetime.fromtimestamp(int(blocked_until), tz=datetime.timezone.utc)
 
-    return blocklist.BlocklistItem(
+    return blocklist.BlocklistEntry(
         id=int(k),
         expires_at=blocked_until,
         reason=f"migrated from old format `{v}`",
@@ -49,7 +49,7 @@ def _convert_legacy_block_format(k, v: str, block_type: blocklist.BlockType) -> 
     )
 
 
-async def _convert_legacy_block_list(foo: dict, blocklist_batch: list[blocklist.BlocklistItem],
+async def _convert_legacy_block_list(foo: dict, blocklist_batch: list[blocklist.BlocklistEntry],
                                      block_type: blocklist.BlockType, bot) -> int:
     skipped = 0
 
@@ -80,7 +80,7 @@ async def _convert_legacy_block_list(foo: dict, blocklist_batch: list[blocklist.
 
         logger.debug(f"migrating id:{k} ts:{blocked_until} blocker:{blocked_by}")
 
-        blocklist_batch.append(blocklist.BlocklistItem(
+        blocklist_batch.append(blocklist.BlocklistEntry(
             id=int(k),
             expires_at=blocked_until,
             reason=f"migrated from old format `{v}`",
@@ -103,7 +103,7 @@ async def migrate_blocklist(bot):
     logger.info(f"preparing to migrate blocklist")
     skipped = 0
 
-    blocklist_batch: list[blocklist.BlocklistItem] = []
+    blocklist_batch: list[blocklist.BlocklistEntry] = []
     logger.info(f"preparing to process {len(blocked_users)} blocked users")
     skipped += await _convert_legacy_block_list(foo=blocked_users, blocklist_batch=blocklist_batch,
                                                 block_type=blocklist.BlockType.USER, bot=bot)

--- a/core/migrations.py
+++ b/core/migrations.py
@@ -1,26 +1,39 @@
 import datetime
 import re
+from typing import Optional
 
 from core import blocklist
 from core.models import getLogger
 
 logger = getLogger(__name__)
 
-old_format_matcher = re.compile("by ([\w]*#[\d]{1,4})(?: until <t:(\d*):f>)?.")
+old_format_matcher = re.compile("by (\w*#\d{1,4})(?: until <t:(\d*):f>)?.")
 
 
-def _convert_legacy_v2_block_format(k, v: dict, block_type: blocklist.BlockType) -> blocklist.BlocklistEntry:
+def _convert_legacy_dict_block_format(k, v: dict, block_type: blocklist.BlockType) -> Optional[blocklist.BlocklistEntry]:
+    """
+    Converts a legacy dict based blocklist entry to the new dataclass format
+
+    Returns None if the block has expired
+    """
+
     blocked_by = int(v["blocked_by"])
     if "until" in v:
         # todo make sure this is the correct from format
         blocked_until = datetime.datetime.fromisoformat(v["until"])
+        # skip if blocked_until occurred in the past
+        if blocked_until < datetime.datetime.now(datetime.timezone.utc):
+            return None
     else:
         blocked_until = None
+
     if "reason" in v:
         reason = v["reason"]
     else:
         reason = None
+
     blocked_ts = datetime.datetime.fromisoformat(v["blocked_at"])
+
     return blocklist.BlocklistEntry(
         id=int(k),
         expires_at=blocked_until,
@@ -31,12 +44,20 @@ def _convert_legacy_v2_block_format(k, v: dict, block_type: blocklist.BlockType)
     )
 
 
-def _convert_legacy_block_format(k, v: str, block_type: blocklist.BlockType) -> blocklist.BlocklistEntry:
+def _convert_legacy_block_format(k, v: str, block_type: blocklist.BlockType) -> Optional[blocklist.BlocklistEntry]:
+    """
+    Converts a legacy string based blocklist entry to the new dataclass format
+
+    Returns None if the block has expired
+    """
+
     match = old_format_matcher.match(v)
-    # blocked_by = match.group(1)
     blocked_until = match.group(2)
     if blocked_until is not None:
         blocked_until = datetime.datetime.fromtimestamp(int(blocked_until), tz=datetime.timezone.utc)
+        # skip if blocked_until occurred in the past
+        if blocked_until < datetime.datetime.now(datetime.timezone.utc):
+            return None
 
     return blocklist.BlocklistEntry(
         id=int(k),
@@ -56,39 +77,22 @@ async def _convert_legacy_block_list(foo: dict, blocklist_batch: list[blocklist.
     for k, v in foo.items():
         # handle new block format
         if type(v) is dict:
-            block = _convert_legacy_v2_block_format(k, v, block_type=block_type)
-            if block.expires_at is not None and block.expires_at < datetime.datetime.now(datetime.timezone.utc):
+            block = _convert_legacy_dict_block_format(k, v, block_type=block_type)
+            if block is None:
                 logger.debug("skipping expired block entry")
                 skipped += 1
                 continue
-            logger.debug(f"migrating new format {v}")
-            blocklist_batch.append(block)
+            logger.debug(f"migrating new format {k}: {v}")
+        else:
+            block = _convert_legacy_block_format(k, v, block_type=block_type)
+            if block is None:
+                logger.debug("skipping expired block entry")
+                skipped += 1
+                continue
+            logger.debug(f"migrating legacy format {k}: {v}")
 
-            continue
+        blocklist_batch.append(block)
 
-        match = old_format_matcher.match(v)
-        blocked_by = match.group(1)
-        blocked_until = match.group(2)
-        if blocked_until is not None:
-            blocked_until = datetime.datetime.fromtimestamp(int(blocked_until), tz=datetime.timezone.utc)
-
-        # skip this item if blocked_until occurred in the past
-        if blocked_until is not None and blocked_until < datetime.datetime.now(datetime.timezone.utc):
-            logger.debug("skipping expired block entry")
-            skipped += 1
-            continue
-
-        logger.debug(f"migrating id:{k} ts:{blocked_until} blocker:{blocked_by}")
-
-        blocklist_batch.append(blocklist.BlocklistEntry(
-            id=int(k),
-            expires_at=blocked_until,
-            reason=f"migrated from old format `{v}`",
-            timestamp=datetime.datetime.utcnow(),
-            # I'm not bothering to fetch the user object here, discords username migrations will have broken all of them
-            blocking_user_id=0,
-            type=blocklist.BlockType.USER
-        ))
         if len(blocklist_batch) >= 100:
             await bot.api.db.blocklist.insert_many([x.__dict__ for x in blocklist_batch])
             blocklist_batch.clear()
@@ -100,21 +104,26 @@ async def migrate_blocklist(bot):
     start_time = datetime.datetime.utcnow()
 
     blocked_users = bot.blocked_users
-    logger.info(f"preparing to migrate blocklist")
+    logger.info("preparing to migrate blocklist")
     skipped = 0
 
     blocklist_batch: list[blocklist.BlocklistEntry] = []
     logger.info(f"preparing to process {len(blocked_users)} blocked users")
     skipped += await _convert_legacy_block_list(foo=blocked_users, blocklist_batch=blocklist_batch,
                                                 block_type=blocklist.BlockType.USER, bot=bot)
-    logger.info(f"processed blocked users")
+    logger.info("processed blocked users")
     logger.info(f"preparing to process {len(bot.blocked_roles)} blocked roles")
     skipped += await _convert_legacy_block_list(foo=bot.blocked_roles, blocklist_batch=blocklist_batch,
                                                 block_type=blocklist.BlockType.ROLE, bot=bot)
-    logger.info(f"processed blocked roles")
+    logger.info("processed blocked roles")
 
     await bot.api.db.blocklist.insert_many([x.__dict__ for x in blocklist_batch])
     blocklist_batch.clear()
+
+    logger.info("clearing old blocklists")
+    bot.blocked_users.clear()
+    bot.blocked_roles.clear()
+    await bot.config.update()
 
     logger.info(f"Migration complete! skipped {skipped} entries")
     logger.info(f"migrated in {datetime.datetime.utcnow() - start_time}")

--- a/core/migrations.py
+++ b/core/migrations.py
@@ -10,7 +10,9 @@ logger = getLogger(__name__)
 old_format_matcher = re.compile("by (\w*#\d{1,4})(?: until <t:(\d*):f>)?.")
 
 
-def _convert_legacy_dict_block_format(k, v: dict, block_type: blocklist.BlockType) -> Optional[blocklist.BlocklistEntry]:
+def _convert_legacy_dict_block_format(
+    k, v: dict, block_type: blocklist.BlockType
+) -> Optional[blocklist.BlocklistEntry]:
     """
     Converts a legacy dict based blocklist entry to the new dataclass format
 
@@ -40,11 +42,13 @@ def _convert_legacy_dict_block_format(k, v: dict, block_type: blocklist.BlockTyp
         reason=reason,
         timestamp=blocked_ts,
         blocking_user_id=blocked_by,
-        type=block_type
+        type=block_type,
     )
 
 
-def _convert_legacy_block_format(k, v: str, block_type: blocklist.BlockType) -> Optional[blocklist.BlocklistEntry]:
+def _convert_legacy_block_format(
+    k, v: str, block_type: blocklist.BlockType
+) -> Optional[blocklist.BlocklistEntry]:
     """
     Converts a legacy string based blocklist entry to the new dataclass format
 
@@ -66,12 +70,13 @@ def _convert_legacy_block_format(k, v: str, block_type: blocklist.BlockType) -> 
         timestamp=datetime.datetime.utcnow(),
         # I'm not bothering to fetch the user object here, discords username migrations will have broken all of them
         blocking_user_id=0,
-        type=block_type
+        type=block_type,
     )
 
 
-async def _convert_legacy_block_list(foo: dict, blocklist_batch: list[blocklist.BlocklistEntry],
-                                     block_type: blocklist.BlockType, bot) -> int:
+async def _convert_legacy_block_list(
+    foo: dict, blocklist_batch: list[blocklist.BlocklistEntry], block_type: blocklist.BlockType, bot
+) -> int:
     skipped = 0
 
     for k, v in foo.items():
@@ -109,12 +114,14 @@ async def migrate_blocklist(bot):
 
     blocklist_batch: list[blocklist.BlocklistEntry] = []
     logger.info(f"preparing to process {len(blocked_users)} blocked users")
-    skipped += await _convert_legacy_block_list(foo=blocked_users, blocklist_batch=blocklist_batch,
-                                                block_type=blocklist.BlockType.USER, bot=bot)
+    skipped += await _convert_legacy_block_list(
+        foo=blocked_users, blocklist_batch=blocklist_batch, block_type=blocklist.BlockType.USER, bot=bot
+    )
     logger.info("processed blocked users")
     logger.info(f"preparing to process {len(bot.blocked_roles)} blocked roles")
-    skipped += await _convert_legacy_block_list(foo=bot.blocked_roles, blocklist_batch=blocklist_batch,
-                                                block_type=blocklist.BlockType.ROLE, bot=bot)
+    skipped += await _convert_legacy_block_list(
+        foo=bot.blocked_roles, blocklist_batch=blocklist_batch, block_type=blocklist.BlockType.ROLE, bot=bot
+    )
     logger.info("processed blocked roles")
 
     await bot.api.db.blocklist.insert_many([x.__dict__ for x in blocklist_batch])


### PR DESCRIPTION
Complete rewrite of how blocking is handled in modmail

The intention of this system is to unify blocking to one new mongodb collection and vastly simplify bot code required to manage it. 

Provides migrations through the [p]migrate command for both legacy string and dict based user blocks. This should allow a seamless migration (though a manual one). Legacy string based block will create new entrys with a timestamp set to the migration time and with an invalid `blocking_user_id` (`0`) since figuring these out would be both a lot of effort and generally useless due to discord username changes. The description of the migrated entry will be 'migrated from old format \`{old block string}\`'.

I've added code to detect legacy blocks and log a warning telling the user how to migrate. It would also be possible to do an unattended automatic migration instead of manually through the command, but I was a bit concerned about unilaterally deciding to do so.