### PR TITLE
Fix persistent notes

### DIFF
--- a/core/thread.py
+++ b/core/thread.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 import discord
 import isodate
 from discord.ext.commands import CommandError, MissingRequiredArgument
+from discord.types.user import User as UserPayload, PartialUser as PartialUserPayload
 from lottie.exporters import exporters as l_exporters
 from lottie.importers import importers as l_importers
 
@@ -259,18 +260,22 @@ class Thread:
             notes = await self.bot.api.find_notes(self.recipient)
             ids = {}
 
+            # This is incredibly cursed and will break every time discord.py changes their internal API method
             class State:
-                def store_user(self, user):
-                    return user
+                # discord.state.ConnectionState.store_user_no_intents
+                def store_user(self, data: typing.Union[UserPayload, PartialUserPayload], *, cache: bool = True) -> discord.user.User:
+                    return discord.user.User(state=self, data=data)
 
             for note in notes:
                 author = note["author"]
 
-                class Author:
-                    name = author["name"]
-                    id = author["id"]
-                    discriminator = author["discriminator"]
-                    display_avatar = SimpleNamespace(url=author["avatar_url"])
+                author_dict: discord.types.user.PartialUser = {
+                    "username": author["name"],
+                    "id": author["id"],
+                    "discriminator": author["discriminator"],
+                    "avatar": author["avatar_url"],
+                    "global_name": "dontlookatme",
+                }
 
                 data = {
                     "id": round(time.time() * 1000 - discord.utils.DISCORD_EPOCH) << 22,
@@ -282,7 +287,7 @@ class Thread:
                     "mention_everyone": None,
                     "tts": None,
                     "content": note["message"],
-                    "author": Author(),
+                    "author": author_dict,
                 }
                 message = discord.Message(state=State(), channel=self.channel, data=data)
                 ids[note["_id"]] = str((await self.note(message, persistent=True, thread_creation=True)).id)


### PR DESCRIPTION
The code here is incredibly cursed and overrides classes in internal discord.py API. it still does this.

All I've done is updated the function signatures and made some of the data slightly better by turning it into a typed dict of the correct type.

A proper fix would require touching core components of modmail (send function, and everything that uses it) in ways I really don't want to do.
