### PR TITLE
Add index for channel_id

### DIFF
--- a/core/clients.py
+++ b/core/clients.py
@@ -476,6 +476,7 @@ class MongoDBClient(ApiClient):
             await coll.create_index(
                 [("messages.content", "text"), ("messages.author.name", "text"), ("key", "text")]
             )
+        await coll.create_index("channel_id", unique=True)
         logger.debug("Successfully configured and verified database indexes.")
 
     async def validate_database_connection(self, *, ssl_retry=True):


### PR DESCRIPTION
Channel_id is the main query field for nearly every log related database operation and isn't indexed in MongoDB . Adding one should speed up all log related database operations, especially in large collections. 

It will result in more storage utilization in MongoDB due to the index size, proportional to the number of modmail logs.