### PR TITLE
Fix is_image attachment attribute to properly reflect whether the attachment is an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ however, insignificant breaking changes do not guarantee a major version bump, s
 # [UNRELEASED]
 
 ### Breaking
-- Completely rewritten blocklist system. Blocklisting now runs off it's own mongoDB collection. This once again introduces backwards incompatible schema changes, so a manual migration is required. You may upgrade from both v4.0 and v4.1 using the `[p]migrate blocklist` command. This removes any need to perform the previous migration steps in v4.1.0, you may upgrade directly to this version. After running the command, blocklist functionality will return and legacy config based blocks will have been deleted. You should always backup your config before migration.
+- Completely rewritten blocklist system. Blocklisting now runs off its own mongoDB collection. This once again introduces backwards incompatible schema changes, so a manual migration is required. You may upgrade from both v4.0 and v4.1 using the `[p]migrate blocklist` command. This removes any need to perform the previous migration steps in v4.1.0, you may upgrade directly to this version. After running the command, blocklist functionality will return and legacy config based blocks will have been deleted. You should always back up your config before migration.
 
 ### Deprecated
 - Legacy blocklist properties are deprecated and no longer function. They now log a warning when used and provide no functionality. They have been replaced with methods in blocklist.py 
 
+### Added
+- Added `content_type` to attachments stored in the database.
+
 ### Fixed
 - Persistent notes have been fixed after the previous discord.py update.
+- `is_image` now is true only if the image is actually an image.
 
 # v4.1.0
 

--- a/core/clients.py
+++ b/core/clients.py
@@ -666,9 +666,11 @@ class MongoDBClient(ApiClient):
                 {
                     "id": a.id,
                     "filename": a.filename,
-                    "is_image": a.width is not None,
+                    # In previous versions this was true for both videos and images
+                    "is_image": a.content_type.startswith("image/"),
                     "size": a.size,
                     "url": a.url,
+                    "content_type": a.content_type,
                 }
                 for a in message.attachments
             ],


### PR DESCRIPTION
This PR adds the `content_type` field to message attachments stored within MongoDB modmail logs and refactors the `is_image` field to be based off content type instead of width. The previous behavior lead to problems with content such as video which also have a width. `content_type` is a direct copy of the information as reported by discord. This will also fix an issue (for newly sent attachments only) in logviewer where videos are broken because it tries to load them as images.

I'm not totally sure why the code was done like this in the first place, because discord.py clearly states that it applies to videos, so maybe there's some actual reason behind this that I'm just unaware of?