### PR TITLE
Synchronize thread NSFW status and title with the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,17 @@ however, insignificant breaking changes do not guarantee a major version bump, s
 ### Added
 - Added `content_type` to attachments stored in the database.
 
+### Changed
+- Changing a threads title or NSFW status immediately updates the status in the database.
+
 ### Fixed
 - Persistent notes have been fixed after the previous discord.py update.
 - `is_image` now is true only if the image is actually an image.
+
+### Internal
+- Add `update_title` and `update_nsfw` methods to `ApiClient` to update thread title and nsfw status in the database.
+- `thread.set_title` now requires `channel_id` to be passed as keyword arguments.
+- New `thread.set_nsfw_status` method to set nsfw status of a thread.
 
 # v4.1.0
 

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -677,7 +677,8 @@ class Modmail(commands.Cog):
     @checks.thread_only()
     async def nsfw(self, ctx):
         """Flags a Modmail thread as NSFW (not safe for work)."""
-        await ctx.channel.edit(nsfw=True)
+        await ctx.thread.set_nsfw_status(True)
+
         sent_emoji, _ = await self.bot.retrieve_emoji()
         await self.bot.add_reaction(ctx.message, sent_emoji)
 
@@ -686,7 +687,8 @@ class Modmail(commands.Cog):
     @checks.thread_only()
     async def sfw(self, ctx):
         """Flags a Modmail thread as SFW (safe for work)."""
-        await ctx.channel.edit(nsfw=False)
+        await ctx.thread.set_nsfw_status(False)
+
         sent_emoji, _ = await self.bot.retrieve_emoji()
         await self.bot.add_reaction(ctx.message, sent_emoji)
 
@@ -769,7 +771,7 @@ class Modmail(commands.Cog):
     @commands.cooldown(1, 600, BucketType.channel)
     async def title(self, ctx, *, name: str):
         """Sets title for a thread"""
-        await ctx.thread.set_title(name)
+        await ctx.thread.set_title(name, ctx.channel.id)
         sent_emoji, _ = await self.bot.retrieve_emoji()
         await ctx.message.pin()
         await self.bot.add_reaction(ctx.message, sent_emoji)

--- a/core/clients.py
+++ b/core/clients.py
@@ -429,6 +429,12 @@ class ApiClient:
     async def get_user_info(self) -> Optional[dict]:
         return NotImplemented
 
+    async def update_title(self, title: str, channel_id: Union[str, int]):
+        return NotImplemented
+
+    async def update_nsfw(self, nsfw: bool, channel_id: Union[str, int]):
+        return NotImplemented
+
 
 class MongoDBClient(ApiClient):
     def __init__(self, bot):
@@ -758,6 +764,13 @@ class MongoDBClient(ApiClient):
                     "url": user.url,
                 }
             }
+
+    async def update_title(self, title: str, channel_id: Union[str, int]):
+        await self.bot.db.logs.find_one_and_update({"channel_id": str(channel_id)}, {"$set": {"title": title}})
+
+    async def update_nsfw(self, nsfw: bool, channel_id: Union[str, int]):
+        await self.bot.db.logs.find_one_and_update({"channel_id": str(channel_id)}, {"$set": {"nsfw": nsfw}})
+
 
 
 class PluginDatabaseClient:

--- a/core/clients.py
+++ b/core/clients.py
@@ -766,11 +766,12 @@ class MongoDBClient(ApiClient):
             }
 
     async def update_title(self, title: str, channel_id: Union[str, int]):
-        await self.bot.db.logs.find_one_and_update({"channel_id": str(channel_id)}, {"$set": {"title": title}})
+        await self.bot.db.logs.find_one_and_update(
+            {"channel_id": str(channel_id)}, {"$set": {"title": title}}
+        )
 
     async def update_nsfw(self, nsfw: bool, channel_id: Union[str, int]):
         await self.bot.db.logs.find_one_and_update({"channel_id": str(channel_id)}, {"$set": {"nsfw": nsfw}})
-
 
 
 class PluginDatabaseClient:

--- a/core/migrations.py
+++ b/core/migrations.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from typing import Optional, List
+from typing import List, Optional
 
 from core import blocklist
 from core.models import getLogger

--- a/core/thread.py
+++ b/core/thread.py
@@ -1218,16 +1218,10 @@ class Thread:
             ids = ",".join(str(i.id) for i in self._other_recipients)
             topic += f"\nOther Recipients: {ids}"
 
-        await asyncio.gather(
-            self.channel.edit(topic=topic),
-            self.bot.api.update_title(title, channel_id)
-        )
+        await asyncio.gather(self.channel.edit(topic=topic), self.bot.api.update_title(title, channel_id))
 
     async def set_nsfw_status(self, nsfw: bool) -> None:
-       await asyncio.gather(
-              self.channel.edit(nsfw=nsfw),
-              self.bot.api.update_nsfw(nsfw, self.channel.id)
-       )
+        await asyncio.gather(self.channel.edit(nsfw=nsfw), self.bot.api.update_nsfw(nsfw, self.channel.id))
 
     async def _update_users_genesis(self):
         genesis_message = await self.get_genesis_message()

--- a/core/thread.py
+++ b/core/thread.py
@@ -1208,7 +1208,7 @@ class Thread:
 
         return " ".join(set(mentions))
 
-    async def set_title(self, title: str) -> None:
+    async def set_title(self, title: str, channel_id: int) -> None:
         topic = f"Title: {title}\n"
 
         user_id = match_user_id(self.channel.topic)
@@ -1218,7 +1218,16 @@ class Thread:
             ids = ",".join(str(i.id) for i in self._other_recipients)
             topic += f"\nOther Recipients: {ids}"
 
-        await self.channel.edit(topic=topic)
+        await asyncio.gather(
+            self.channel.edit(topic=topic),
+            self.bot.api.update_title(title, channel_id)
+        )
+
+    async def set_nsfw_status(self, nsfw: bool) -> None:
+       await asyncio.gather(
+              self.channel.edit(nsfw=nsfw),
+              self.bot.api.update_nsfw(nsfw, self.channel.id)
+       )
 
     async def _update_users_genesis(self):
         genesis_message = await self.get_genesis_message()


### PR DESCRIPTION
Refactors title & nsfw command and associated code to also update the modmail log in mongodb.

!Changes signature of `thread.set_title()`

adds `update_nsfw` and `update_title` methods to the mongodb client